### PR TITLE
fix(lobpcg): error message had incorrect parameters

### DIFF
--- a/src/lobpcg/algorithm.rs
+++ b/src/lobpcg/algorithm.rs
@@ -131,8 +131,8 @@ pub fn lobpcg<A: NdFloat + Sum, F: Fn(ArrayView2<A>) -> Array2<A>, G: Fn(ArrayVi
     if size_x > n {
         return Err((
             LinalgError::NotThin {
-                rows: size_x,
-                cols: n,
+                rows: n,
+                cols: size_x,
             },
             None,
         ));


### PR DESCRIPTION
This caused the error message to be confusing, e.g. on a [3, 5] matrix: `Expected matrix rows(5) >= cols(3)`.